### PR TITLE
Added requirements.txt and info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Dependencies
 
 + A C++ compiler, ``make``, and [GMP](https://gmplib.org/) to build the MaxSAT solver: [Open-WBO-Inc](https://github.com/sbjoshi/Open-WBO-Inc)
-+ Python 3.8 or later with the third-party packages ``qiskit``, ``scipy``, and ``pysat``, which can all be installed via ``pip``
++ Python 3.8 or later with the third-party packages ``qiskit``, ``scipy``, and ``pysat``, which can all be installed via ``pip`` or by running ``pip install -r requirements.txt``
 
 There is also a Docker image available [here](https://hub.docker.com/repository/docker/abtinm/qmapping) that provides a Ubuntu environment with the above preinstalled.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+qiskit
+scipy
+python-sat


### PR DESCRIPTION
Added a `requirements.txt` as I spent a day trying to figure out why `pysat` wasn't working, and it's because it's called `python-say` rather than `pysat` when installed via `pip`.  Figured adding this might alleviate that headache for anyone else. 